### PR TITLE
Update install-debuntu.sh

### DIFF
--- a/install-debuntu.sh
+++ b/install-debuntu.sh
@@ -194,6 +194,7 @@ if [[ $? -gt 0 ]]; then
     echo "ERROR: Failed to install key. Use ${CONTACT_URL} to find us for troubleshooting."
     exit 1
 fi
+chmod 644 /etc/apt/keyrings/jellyfin.gpg
 echo
 
 # Check for and remove the obsoleted jellyfin.list configuration if present


### PR DESCRIPTION
Ensure the installed keys are readable by everyone. The sources.list includes:

> It is specified as a list of absolute paths to keyring files (have to be
           accessible and readable for the _apt system user, so ensure everyone has
           read-permissions on the file) and fingerprints of keys to select from these keyrings.
           
           
This prevents a fail during apt-update

```
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 49023CD01DE21A7B
Reading package lists... Done
W: GPG error: https://repo.jellyfin.org/debian bookworm InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 49023CD01DE21A7B
E: The repository 'https://repo.jellyfin.org/debian bookworm InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```