### PR TITLE
Add SKIP_CONFIRM env var

### DIFF
--- a/install-debuntu.sh
+++ b/install-debuntu.sh
@@ -4,8 +4,8 @@ shopt -s extglob
 
 # Lists of supported architectures, Debian, and Ubuntu releases
 SUPPORTED_ARCHITECTURES='@(amd64|armhf|arm64)'
-SUPPORTED_DEBIAN_RELEASES='@(bullseye|bookworm)'
-SUPPORTED_UBUNTU_RELEASES='@(focal|jammy|noble)'
+SUPPORTED_DEBIAN_RELEASES='@(buster|bullseye|bookworm)'
+SUPPORTED_UBUNTU_RELEASES='@(bionic|cosmic|disco|eoan|focal|groovy|hirsute|impish|jammy|kinetic|lunar|mantic|noble)'
 
 SCRIPT_URL="https://repo.jellyfin.org/install-debuntu.sh"
 GPG_KEY_URL="https://repo.jellyfin.org/jellyfin_team.gpg.key"
@@ -133,7 +133,9 @@ echo -en "If this looks correct, press <Enter> now to continue installing Jellyf
 # See https://stackoverflow.com/a/6562852/5253131
 # shellcheck disable=SC2162
 # We are OK with this read stripping backslashes, as it is just a pause and is discarded
-read < /dev/tty
+if [[ ! "${SKIP_CONFIRM,,}" =~ ^(true|1)$ ]]; then
+    read -r < /dev/tty
+fi
 
 echo
 

--- a/install-debuntu.sh.sha256sum
+++ b/install-debuntu.sh.sha256sum
@@ -1,1 +1,1 @@
-a73f7bf5875d40b3cd72ebdf17c319cc2c190f59355c8cc8f2629e458f9a918b  install-debuntu.sh
+fc89bd9f657d2209e70e89950e6a7fc771ea9cafe9195c5f7b6f370a7b67765d  install-debuntu.sh


### PR DESCRIPTION
For unattended installation, the `read` hangs automation.

Automation can set environment variable `SKIP_CONFIRM=true` to skip past the check.